### PR TITLE
Avoid bashism in makefiles for the sake of systems where /bin/sh is t…

### DIFF
--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -1,5 +1,5 @@
 base_image:=gcr.io/cloudrun/hello
-load_envs:=source ./.env
+load_envs:=. ./.env
 
 all: check init apply push_repo done
 
@@ -19,7 +19,7 @@ apply:
 
 .PHONY: push_repo
 push_repo:
-	git config --global credential.https://source.developers.google.com.helper gcloud.sh  
+	git config --global credential.https://source.developers.google.com.helper gcloud.sh
 	repo_url=$(shell terraform output -no-color | grep repo_url | awk '{print $$3}') && \
 	if [ -z "$(shell git remote | grep google)" ]; then \
 		git remote add google "$$repo_url"; \


### PR DESCRIPTION
…he default

Fixes this error during 'make':
    source ./.env && terraform apply
    /bin/sh: 1: source: not found
    Makefile:18: recipe for target 'apply' failed
    make: *** [apply] Error 127
The default shell for make (at least on Ubuntu 18.04) is still /bin/sh,
which does not like 'source'; so use '.' instead for sourcing files.