### PR TITLE
go-cleanarch: override infrastructure layer name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ proto:
 
 .PHONY: lint
 lint:
-	@go-cleanarch
+	@go-cleanarch -infrastructure ports
 	@./scripts/lint.sh common
 	@./scripts/lint.sh trainer
 	@./scripts/lint.sh trainings

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ proto:
 
 .PHONY: lint
 lint:
-	@go-cleanarch -infrastructure ports
+	@go-cleanarch -interfaces ports -infrastructure adapters
 	@./scripts/lint.sh common
 	@./scripts/lint.sh trainer
 	@./scripts/lint.sh trainings


### PR DESCRIPTION
Due to [go-cleanarch readme](https://github.com/roblaszczak/go-cleanarch#allowed-layer_name) default infrastructure layer package name is `infrastructure` or `infra`.

In this project infrastructure layer package named `ports`. 

I filtered modules and layers from debug  `go-cleanarch` output. There was no infrastructure layer
```
$ go-cleanarch -debug  ./ 2>&1 | grep -v 'Layer:}' | grep 'metadata: {Module' | cut -d' ' -f 6-7 | sort | uniq              
{Module:trainer Layer:application}
{Module:trainer Layer:domain}
{Module:trainer Layer:interfaces}
{Module:trainings Layer:application}
{Module:trainings Layer:domain}
{Module:trainings Layer:interfaces}
```

With overrided `-infrastructure` flag infrastructure layer appears in output
```
$ go-cleanarch -debug -infrastructure ports ./ 2>&1 | grep -v 'Layer:}' | grep 'metadata: {Module' | cut -d' ' -f 6-7 | sort | uniq
{Module:trainer Layer:application}
{Module:trainer Layer:domain}
{Module:trainer Layer:infrastructure}
{Module:trainer Layer:interfaces}
{Module:trainings Layer:application}
{Module:trainings Layer:domain}
{Module:trainings Layer:infrastructure}
{Module:trainings Layer:interfaces}
```