### PR TITLE
Fix CORS middleware allowed origins check

### DIFF
--- a/internal/common/server/http.go
+++ b/internal/common/server/http.go
@@ -80,7 +80,7 @@ func addAuthMiddleware(router *chi.Mux) {
 
 func addCorsMiddleware(router *chi.Mux) {
 	allowedOrigins := strings.Split(os.Getenv("CORS_ALLOWED_ORIGINS"), ";")
-	if len(allowedOrigins) == 0 {
+	if len(allowedOrigins) == 1 && allowedOrigins[0] == "" {
 		return
 	}
 


### PR DESCRIPTION
This PR fixes an issue in the `addCorsMiddleware` function where the if condition would never evaluate to true. The updated check ensures that the CORS middleware is applied only when the `CORS_ALLOWED_ORIGINS` environment variable is set and not empty.
